### PR TITLE
fix header typo

### DIFF
--- a/nginx.conf
+++ b/nginx.conf
@@ -16,7 +16,7 @@ http {
         root /usr/share/nginx/html;
         autoindex on;
 
-        add_header Access-Control-Allow-Origin: "*" always;
+        add_header Access-Control-Allow-Origin "*" always;
 
         location / {
             try_files $uri $uri/ =404;


### PR DESCRIPTION
currently:
```
$ curl -Is https://psl.hrsn.dev/public_suffix_list.min.dat | grep -i access-control
access-control-allow-origin: : *
```
with fix (locally):
```
$ curl -Is localhost:8081 | grep -i access-control
Access-Control-Allow-Origin: * 
```